### PR TITLE
Add --reset flag to clear game state and log out all users

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ A digital card dealer for in-person sessions of Texas Hold'em poker games. Playe
    npm start
    ```
 
+   **Optional: Start with reset** (clears game state and logs out all users)
+   ```bash
+   npm run start:reset
+   # or
+   node server/index.js --reset
+   ```
+
 5. **Open your browser**
    ```
    Navigate to http://localhost:3000
@@ -212,6 +219,22 @@ See [DEPLOYMENT.md](DEPLOYMENT.md) for detailed deployment instructions for Digi
 - Change `SESSION_SECRET` in production
 
 ## Troubleshooting
+
+### Resetting Game State
+If you need to clear all active games and log out all users:
+```bash
+npm run start:reset
+```
+
+This will:
+- Reset the game state (clear players, cards, dealer position)
+- Log out all users (clear all sessions)
+- Start the server with a clean slate
+
+Useful when:
+- Starting a new game session
+- Testing from a fresh state
+- Resolving game state corruption issues
 
 ### Database Issues
 If you encounter database errors:

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,0 +1,72 @@
+# Release Notes - Poker Dealer
+
+## 2025-11-27 - feature/reset-game-parameter
+
+### New Feature
+- **Reset Command Line Flag**: Added `--reset` parameter for clean server startup
+  - Clears all game state (players, cards, dealer position, game phase)
+  - Logs out all users by clearing all active sessions
+  - Useful for starting fresh game sessions or testing scenarios
+
+### Usage
+```bash
+# Using npm script
+npm run start:reset
+
+# Direct node command
+node server/index.js --reset
+```
+
+### What Gets Reset
+- **Game State**: All players removed, cards cleared, dealer position reset, phase set to 'waiting'
+- **User Sessions**: All active sessions deleted, forcing all users to log in again
+- **Database**: Only sessions and game_state tables affected; user accounts remain intact
+
+### Technical Details
+- Added `deleteAll()` method to session operations in `server/db.js`
+- Modified `server/index.js` to detect `--reset` flag via `process.argv`
+- Reset operations execute before server starts listening
+- Added `start:reset` npm script in `package.json`
+- Updated README.md with reset documentation
+
+---
+
+## 2025-11-26 - feature/poker-dealer-app
+
+### Initial Release
+Complete Texas Hold'em digital dealer application with the following features:
+
+#### Core Functionality
+- Support for up to 10 simultaneous players
+- Real-time WebSocket communication for instant updates
+- Automatic dealer rotation after each hand
+- Mobile-responsive design for phones and tablets
+- Public community cards display (no authentication required)
+
+#### Authentication & Sessions
+- Simple email/password authentication
+- 10 pre-configured test accounts
+- httpOnly session cookies for security
+- 24-hour session duration
+
+#### Game Features
+- Deal hole cards (2 per player, visible only to owner)
+- Deal community cards (5 cards, revealed progressively)
+- Dealer controls for card dealing and revealing
+- Phases: Pre-Flop → Flop (3 cards) → Turn (1 card) → River (1 card)
+- Player order based on join sequence
+- Random initial dealer selection
+
+#### Bug Fixes Applied
+- Fixed cookie path issue preventing session persistence
+- Fixed httpOnly cookie access for WebSocket authentication
+- Fixed login infinite loop caused by automatic redirects
+- Added proper fetch credentials for cookie support
+- Changed sameSite policy from 'strict' to 'lax'
+
+### Technology Stack
+- Backend: Node.js with Express
+- WebSocket: ws library
+- Database: SQLite (embedded)
+- Frontend: Vanilla HTML, CSS, and JavaScript
+- Deployment: Docker containerization

--- a/WhatToTest.en-CA.txt
+++ b/WhatToTest.en-CA.txt
@@ -10,8 +10,17 @@ What's New:
 - Automatic dealer rotation after each hand
 - Public community cards display for shared screens (no authentication required)
 
-Latest Bug Fixes (2025-11-26):
-------------------------------
+Latest Changes (2025-11-27):
+----------------------------
+- Added `--reset` command line flag to reset game state and log out all users
+  - Usage: `npm run start:reset` or `node server/index.js --reset`
+  - Clears all active game data (players, cards, dealer position)
+  - Logs out all users by clearing all sessions
+  - Useful for starting fresh game sessions or testing
+- Card suit symbols now display in appropriate colors (hearts/diamonds in red, clubs/spades in black)
+
+Previous Bug Fixes (2025-11-26):
+---------------------------------
 - Fixed cookie path issue preventing session cookies from being sent with all requests
 - Added explicit `path: '/'` to all cookie operations to ensure site-wide availability
 - Fixed httpOnly cookie access issue by returning token in /api/auth/session response

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "server/index.js",
   "scripts": {
     "start": "node server/index.js",
+    "start:reset": "node server/index.js --reset",
     "dev": "node --watch server/index.js",
     "db:init": "node scripts/init-db.js",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/server/db.js
+++ b/server/db.js
@@ -67,6 +67,11 @@ const sessionOps = {
     deleteByUserId(userId, callback) {
         const query = 'DELETE FROM sessions WHERE user_id = ?';
         getDb().run(query, [userId], callback);
+    },
+
+    deleteAll(callback) {
+        const query = 'DELETE FROM sessions';
+        getDb().run(query, [], callback);
     }
 };
 


### PR DESCRIPTION
## Description

This PR adds a `--reset` command line parameter that clears game state and logs out all users when starting the server. This is useful for:
- Starting fresh game sessions
- Testing from a clean state
- Resolving game state corruption issues

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## How to Test

### Test Reset Functionality

1. **Set up initial state:**
   ```bash
   npm start
   ```
   - Login with a test account (alice@example.com / password123)
   - Join the game
   - Have dealer deal some cards

2. **Stop the server** (Ctrl+C)

3. **Start with reset flag:**
   ```bash
   npm run start:reset
   # or
   node server/index.js --reset
   ```

4. **Verify reset behavior:**
   - Check console output for reset messages:
     ```
     RESET MODE: Clearing game state and sessions
     Resetting game state...
     ✓ Game state reset
     Clearing all active sessions...
     ✓ All sessions cleared
     ✓ All users logged out
     ```

5. **Verify in browser:**
   - Navigate to http://localhost:3000
   - Should be on login page (even if previously logged in)
   - Login and join game
   - Should start with no players, no cards, waiting phase

### Test Normal Start (No Reset)

1. **Start normally:**
   ```bash
   npm start
   ```

2. **Verify normal behavior:**
   - No reset messages in console
   - Game state persists from previous session
   - User sessions remain active

## What Gets Reset

✓ **Game State:**
- Player list cleared
- All cards removed
- Dealer position reset to 0
- Game phase set to 'waiting'
- Cards dealt flag set to false

✓ **User Sessions:**
- All active sessions deleted
- All users logged out
- Forces fresh login on next access

✗ **User Accounts:**
- User accounts NOT affected
- Test accounts remain in database
- Passwords unchanged

## Files Modified

- **server/db.js**: Added `deleteAll()` method to session operations
- **server/index.js**: Added reset flag detection and execution logic
  - Checks `process.argv` for `--reset` flag
  - Executes reset before server starts listening
  - Displays confirmation messages
- **package.json**: Added `start:reset` npm script
- **README.md**: Updated with reset documentation
- **WhatToTest.en-CA.txt**: Added reset feature to test list
- **ReleaseNotes.md**: Created with version history

## Usage Examples

```bash
# Using npm script (recommended)
npm run start:reset

# Direct node command
node server/index.js --reset

# In Docker (example)
docker run -p 3000:3000 poker-dealer node server/index.js --reset
```

## Console Output

When starting with `--reset`:
```
===========================================
RESET MODE: Clearing game state and sessions
===========================================

Resetting game state...
✓ Game state reset
Clearing all active sessions...
✓ All sessions cleared
✓ All users logged out

===========================================
Poker Dealer Server Started
===========================================
Server running on: http://localhost:3000
Environment: development
Reset Mode: Game state and sessions cleared
===========================================
```

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added/updated as needed (manual testing instructions provided)
- [x] Documentation updated (README.md, WhatToTest.en-CA.txt, ReleaseNotes.md)
- [x] No breaking changes
- [x] Reset only affects game state and sessions, not user accounts
- [x] Works with both npm script and direct node command

## Future Enhancements

Potential improvements for future PRs:
- Add confirmation prompt in interactive mode
- Add `--reset-confirm` flag for automated environments
- Add option to reset only game state OR only sessions
- Add reset statistics (number of sessions cleared, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)