### PR TITLE
Add fold button with slide-to-fold safety mechanism (Issue #19)

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,72 @@
 # Release Notes - Poker Dealer
 
+## 2025-12-31 - feature/fold-button
+
+### New Feature
+
+#### Fold Button with Safety Switch (Issue #19)
+- **Slide-to-Fold Control**: Players can fold their hand using a slide action
+  - Red gradient slide track appears after cards are dealt
+  - Must slide past 90% to confirm fold (prevents accidental folds)
+  - Slide button uses 🃏 icon for clear visual distinction
+  - Works on both desktop (mouse) and mobile (touch)
+
+- **Folded State Visual Feedback**:
+  - Folded players show "FOLDED" badge (gray) next to their name
+  - Player item becomes semi-transparent with dashed border
+  - Player name gets strikethrough styling
+  - Hole cards section shows "You have folded" message
+
+- **Game State Tracking**:
+  - Fold state persists across page refreshes
+  - All players see who has folded in real-time
+  - Active player count tracked and broadcast
+  - Fold state resets when hand completes
+
+### Technical Details
+
+#### Backend Changes
+- Modified `server/game/poker-game.js`:
+  - Added `foldedPlayers` Set to track folded players
+  - Added `foldPlayer(userId)` method
+  - Added `hasPlayerFolded(userId)` method
+  - Added `getActivePlayerCount()` method
+  - Updated `getGameState()` to include `hasFolded` flag per player
+  - Updated `toJSON()` and `fromJSON()` for fold state persistence
+  - Clear folded players in `completeHand()`
+
+- Modified `server/websocket.js`:
+  - Added `fold-hand` WebSocket message handler
+  - Added `handleFoldHand()` function
+  - Broadcasts `player-folded` notification to all clients
+
+#### Frontend Changes
+- Modified `views/game.ejs`:
+  - Added slide-to-fold HTML component
+
+- Modified `public/js/game.js`:
+  - Added `fold-confirmed` and `player-folded` WebSocket handlers
+  - Added `updateSlideToFoldControl()` function
+  - Added slide-to-fold functionality (setupSlideToFold, startSlideFold, doSlideFold, endSlideFold)
+  - Added `foldMyHand()` function
+  - Updated player list to show folded badge and styling
+
+- Modified `public/css/game.css`:
+  - Added `.slide-to-fold-container` and related slide styles (red theme)
+  - Added `.player-folded-badge` styling (gray)
+  - Added `.player-item.is-folded` styling (opacity, dashed border)
+  - Added `.folded-message` styling
+
+### Usage
+1. Cards must be dealt before fold option appears
+2. Red "Slide to Fold" track appears below hole cards
+3. Slide the button past 90% to confirm fold
+4. Folded player's cards are hidden
+5. Other players see the FOLDED badge
+6. Fold state resets when hand completes
+
+---
+
 ## 2025-12-31 - feature/manual-dealer-selection
 
 ### New Feature

--- a/WhatToTest.en-CA.txt
+++ b/WhatToTest.en-CA.txt
@@ -12,6 +12,15 @@ What's New:
 
 Latest Changes (2025-12-31):
 ----------------------------
+- **Fold Button with Safety Switch (Issue #19)**
+  - Slide-to-fold control appears below hole cards after cards are dealt
+  - Red gradient slide track prevents accidental folds (must slide 90%)
+  - Folded players show "FOLDED" badge (gray) next to their name
+  - Player item becomes semi-transparent with strikethrough name
+  - Hole cards show "You have folded" message after folding
+  - Fold state persists across refreshes and resets when hand completes
+  - All players see who has folded in real-time
+
 - **Manual Dealer Selection (Issue #17)**
   - Click directly on a player's name to select them as dealer
   - Player items show dashed green border when selectable
@@ -733,6 +742,63 @@ Scenario 36: Manual Dealer Selection - Multiple Devices
 4. On Device 2, click to select a specific player as dealer
 5. On all devices, verify the dealer selection is reflected immediately
 6. Verify all devices show the same dealer, SB, and BB assignments
+
+Scenario 37: Fold Button - Slide to Fold
+1. Start server with `npm run start:reset` for clean state
+2. Login with 3-4 players on separate devices
+3. All players join the game and select dealer
+4. Dealer deals cards
+5. Verify red "Slide to Fold" track appears below hole cards
+6. On one player's device, slide the button partway and release
+7. Verify button slides back to start (not folded)
+8. Slide the button past 90% of track width
+9. Verify fold is confirmed with success message
+10. Verify hole cards section shows "You have folded" message
+11. Verify slide-to-fold control disappears after folding
+12. Verify slide-to-show control also disappears (can't show folded cards)
+
+Scenario 38: Fold Button - Player List Updates
+1. Login with 3 players (Gary, Neave, Harish) on separate devices
+2. All join game, select dealer, deal cards
+3. On Gary's device, slide to fold
+4. On all devices, verify:
+   - Gary's player item shows "FOLDED" badge (gray)
+   - Gary's player item is semi-transparent with dashed border
+   - Gary's name has strikethrough styling
+5. On Neave's device, also fold
+6. Verify both Gary and Neave show folded state on all devices
+7. Harish should still see their cards and fold option
+
+Scenario 39: Fold Button - Multi-Device Sync
+1. Login with 4 players on 4 different devices
+2. All join game, deal cards
+3. On Device 1, player folds
+4. On Devices 2, 3, 4, verify fold notification appears
+5. Verify all devices show correct folded state
+6. Complete the hand (flip through all phases)
+7. Deal new hand
+8. Verify fold states are reset - no players show as folded
+9. Verify fold controls reappear for all players
+
+Scenario 40: Fold Button - Persistence
+1. Login with 2-3 players, deal cards
+2. One player folds
+3. Refresh the folded player's browser
+4. Verify fold state persists after refresh
+5. Verify hole cards still show "You have folded"
+6. Verify slide controls don't reappear
+7. Complete hand and deal again
+8. Verify fold state is reset after new deal
+
+Scenario 41: Fold Button - Mobile Touch
+1. Login on mobile device (iOS or Android)
+2. Join game with other players, deal cards
+3. Verify red slide track is visible on mobile
+4. Touch and drag button slowly across track
+5. Lift finger before 90% - verify button returns
+6. Touch and drag past 90%
+7. Verify fold is confirmed
+8. Test in portrait and landscape orientations
 
 For Issues:
 ----------

--- a/public/css/game.css
+++ b/public/css/game.css
@@ -306,6 +306,58 @@
     user-select: none;
 }
 
+/* Slide to Fold Control */
+.slide-to-fold-container {
+    margin-top: var(--spacing-md);
+    padding: var(--spacing-md);
+}
+
+.slide-track-fold {
+    position: relative;
+    width: 100%;
+    height: 60px;
+    background: linear-gradient(135deg, #e74c3c 0%, #c0392b 100%);
+    border-radius: 30px;
+    display: flex;
+    align-items: center;
+    overflow: hidden;
+    box-shadow: 0 4px 15px rgba(231, 76, 60, 0.3);
+}
+
+.slide-instruction-fold {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    color: white;
+    font-weight: bold;
+    font-size: var(--font-md);
+    pointer-events: none;
+    user-select: none;
+    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+.slide-button-fold {
+    position: absolute;
+    left: 0;
+    width: 70px;
+    height: 50px;
+    background-color: white;
+    border-radius: 25px;
+    margin: 5px;
+    cursor: grab;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.3);
+    transition: transform 0.1s ease;
+    touch-action: none;
+}
+
+.slide-button-fold:active {
+    cursor: grabbing;
+    transform: scale(1.05);
+}
+
 /* Revealed Hands Display */
 .cards-display-container {
     display: flex;
@@ -493,6 +545,34 @@
     padding: var(--spacing-xs) var(--spacing-sm);
     border-radius: var(--radius-sm);
     font-size: var(--font-xs);
+    font-weight: bold;
+}
+
+/* Folded Player Badge */
+.player-folded-badge {
+    background-color: #7f8c8d;
+    color: white;
+    padding: var(--spacing-xs) var(--spacing-sm);
+    border-radius: var(--radius-sm);
+    font-size: var(--font-xs);
+    font-weight: bold;
+}
+
+/* Folded Player Styling */
+.player-item.is-folded {
+    opacity: 0.5;
+    background-color: rgba(127, 140, 141, 0.1);
+    border: 1px dashed #7f8c8d;
+}
+
+.player-item.is-folded .player-name {
+    text-decoration: line-through;
+    color: var(--color-text-muted);
+}
+
+/* Folded Message in Hole Cards */
+.folded-message {
+    color: #e74c3c;
     font-weight: bold;
 }
 

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -104,6 +104,16 @@
                                 </div>
                             </div>
                         </div>
+
+                        <!-- Slide to Fold Control -->
+                        <div id="slideToFoldContainer" class="slide-to-fold-container hidden">
+                            <div class="slide-track-fold">
+                                <div class="slide-instruction-fold">Slide to Fold →</div>
+                                <div id="slideFoldButton" class="slide-button-fold">
+                                    <span class="slide-icon">🃏</span>
+                                </div>
+                            </div>
+                        </div>
                     </section>
 
                     <!-- Dealer Controls (only shown for dealer) -->


### PR DESCRIPTION
## Summary
- Add slide-to-fold control that appears after cards are dealt
- Red gradient slide track prevents accidental folds (must slide 90%)
- Folded players show "FOLDED" badge and visual distinction
- Fold state syncs in real-time across all devices
- Fold state persists across page refreshes

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## How to Test
1. Start server with `npm run start:reset` for clean state
2. Login with 2+ players on separate devices/tabs
3. All players join game, select dealer, deal cards
4. Verify red "Slide to Fold" track appears below hole cards
5. Try sliding partway and release - button should return
6. Slide past 90% to confirm fold
7. Verify:
   - Hole cards show "You have folded"
   - Player list shows FOLDED badge (gray)
   - Player item is semi-transparent with strikethrough name
   - Other players see the fold in real-time
8. Complete hand and deal again - fold states reset

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added/updated as needed
- [x] Documentation updated (ReleaseNotes.md, WhatToTest.en-CA.txt)
- [x] No breaking changes

## Files Changed
- `server/game/poker-game.js` - Fold state tracking and methods
- `server/websocket.js` - fold-hand message handler
- `views/game.ejs` - Slide-to-fold HTML component
- `public/js/game.js` - Slide-to-fold functionality and fold state UI
- `public/css/game.css` - Fold control and folded player styling
- `ReleaseNotes.md` - Feature documentation
- `WhatToTest.en-CA.txt` - Test scenarios

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)