### PR TITLE
Fix 4 GitHub issues (#34, #35, #36, #37)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -44,7 +44,12 @@
       "mcp__puppeteer__puppeteer_evaluate",
       "mcp__puppeteer__puppeteer_select",
       "Bash(git -c user.name=\"Claude Code\" -c user.email=\"claude-code@pelau.com\" commit -m \"$\\(cat <<''EOF''\nAdd footer refresh link to game and community pages\n\nThe footer \"Made with 💕 in the 6ix\" text now reloads the page when\nclicked, matching the existing behavior on the login page.\n\nCo-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>\nEOF\n\\)\")",
-      "Bash(gh pr list:*)"
+      "Bash(gh pr list:*)",
+      "mcp__puppeteer__puppeteer_fill",
+      "Bash(git -C /Users/darren/code/poker-dealer status)",
+      "Bash(git -C /Users/darren/code/poker-dealer diff)",
+      "Bash(git -C /Users/darren/code/poker-dealer log --oneline -5)",
+      "Bash(git -C /Users/darren/code/poker-dealer add WhatToTest.en-CA.txt public/css/common.css public/js/dealer-controls.js public/js/game.js .claude/settings.local.json)"
     ],
     "deny": [],
     "ask": []

--- a/WhatToTest.en-CA.txt
+++ b/WhatToTest.en-CA.txt
@@ -1,8 +1,31 @@
 Poker Dealer - Initial Release
 ================================
 
-Latest Changes (2026-02-01):
+Latest Changes (2026-02-18):
 ----------------------------
+**Fix for 4 GitHub Issues (Issues #34, #35, #36, #37)**
+
+- **Issue #34: Broke button emoji fix**
+  - Changed "mark as broke" toggle emoji from 💸 (flying money) to 🚫 (no entry)
+  - 💰 (money bag) still used for "mark as active" — clearer visual distinction
+
+- **Issue #35: Dealer controls vanish on page refresh**
+  - Fixed race condition where dealer controls disappeared after full page refresh
+  - Removed setTimeout(500ms) initialization; controls now set up synchronously with WebSocket handlers
+  - Dealer controls reliably appear on refresh, reconnect, and first load
+
+- **Issue #36: Slide buttons hidden for broke players**
+  - Slide-to-show and slide-to-fold controls no longer appear for broke players
+  - Added check: player must have hole cards (not just cardsDealt flag) for controls to show
+
+- **Issue #37: Large overlay animations replace subtle toasts**
+  - Replaced small green success bar with full-screen centered overlay notifications
+  - Each event category has a distinct emoji icon, color tint, and animation
+  - Categories: deal (green/🎴), reveal (blue/♠), fold (red/✋), join (green/✅), dealer (gold/⭐), timer (orange/⏰), broke (yellow/💰), shuffle (blue/🔄), reset (red/🔄)
+  - 2-second scale-in + fade-out CSS animation, pointer-events: none (no tap blocking)
+
+Previous Changes (2026-02-01):
+------------------------------
 **Fix for 7 GitHub Issues (Issues #18, #27, #28, #29, #30, #31, #32)**
 
 - **Issue #18: Fixed "reveal/show cards" requiring refresh**

--- a/public/css/common.css
+++ b/public/css/common.css
@@ -102,17 +102,51 @@ input[type="password"]:focus {
     display: block;
 }
 
-.success-message {
-    background-color: var(--color-success);
-    color: white;
-    padding: var(--spacing-md);
-    border-radius: var(--radius-md);
-    margin-bottom: var(--spacing-md);
-    display: none;
+/* Overlay notification (replaces old .success-message) */
+.overlay-notification {
+    position: fixed;
+    inset: 0;
+    z-index: var(--z-modal);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    animation: overlayFadeInOut 2s ease forwards;
 }
 
-.success-message.show {
-    display: block;
+.overlay-icon {
+    font-size: 4rem;
+    margin-bottom: var(--spacing-md);
+    text-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+}
+
+.overlay-text {
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: white;
+    text-align: center;
+    text-shadow: 0 2px 8px rgba(0, 0, 0, 0.7);
+    padding: 0 var(--spacing-lg);
+}
+
+/* Category color tints */
+.overlay-deal    { background: rgba(46, 204, 113, 0.35); }
+.overlay-reveal  { background: rgba(52, 152, 219, 0.35); }
+.overlay-fold    { background: rgba(231, 76, 60, 0.35); }
+.overlay-join    { background: rgba(46, 204, 113, 0.35); }
+.overlay-dealer  { background: rgba(243, 156, 18, 0.35); }
+.overlay-timer   { background: rgba(243, 156, 18, 0.35); }
+.overlay-broke   { background: rgba(243, 156, 18, 0.35); }
+.overlay-shuffle { background: rgba(52, 152, 219, 0.35); }
+.overlay-reset   { background: rgba(231, 76, 60, 0.35); }
+.overlay-default { background: rgba(255, 255, 255, 0.2); }
+
+@keyframes overlayFadeInOut {
+    0%   { opacity: 0; transform: scale(0.5); }
+    15%  { opacity: 1; transform: scale(1); }
+    75%  { opacity: 1; transform: scale(1); }
+    100% { opacity: 0; transform: scale(1.05); }
 }
 
 .loading {

--- a/public/js/dealer-controls.js
+++ b/public/js/dealer-controls.js
@@ -145,11 +145,8 @@ function shuffleDeck() {
     }
 
     wsClient.send('shuffle-deck');
-    showSuccess('Deck has been shuffled!');
+    showOverlay('Deck has been shuffled!', 'shuffle');
 }
 
-// Initialize dealer controls when game is ready
-window.addEventListener('load', () => {
-    // Wait a bit for wsClient to be initialized
-    setTimeout(setupDealerControls, 500);
-});
+// setupDealerControls() is called directly from game.js init()
+// to avoid race conditions with WebSocket game-state messages.


### PR DESCRIPTION
## Summary
- **#34**: Replace broke toggle emoji from 💸 to 🚫 for clearer visual distinction
- **#35**: Fix dealer controls vanishing on page refresh — removed `setTimeout(500ms)` race condition, controls now initialize synchronously with WebSocket handlers
- **#36**: Hide slide-to-show/fold buttons for broke players who have no hole cards
- **#37**: Replace small green toast with full-screen overlay animations — 10 event categories with distinct emoji icons, color tints, and 2s scale-in/fade-out CSS animation

## Test plan
- [ ] Verify 🚫 emoji on broke toggle button (not 💸)
- [ ] Refresh page as dealer — confirm Deal/Flip/Shuffle buttons remain visible
- [ ] Mark player broke, deal cards, confirm broke player sees no slide buttons
- [ ] Trigger deal/fold/reveal actions — confirm large centered overlay with icon appears and auto-dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)