### PR TITLE
Add dealer timer pause/resume/reset controls (#49)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -53,7 +53,8 @@
       "Bash(git -C:*)",
       "Bash(git -c user.name=\"Claude Code\" -c user.email=\"claude-code@pelau.com\" add:*)",
       "Bash(git -c:*)",
-      "Bash(gh pr merge:*)"
+      "Bash(gh pr merge:*)",
+      "Bash(./scripts/workflow.sh issue-49-pause-timer:*)"
     ],
     "deny": [],
     "ask": []

--- a/WhatToTest.en-CA.txt
+++ b/WhatToTest.en-CA.txt
@@ -1,8 +1,20 @@
 Poker Dealer - Initial Release
 ================================
 
-Latest Changes (2026-03-01):
+Latest Changes (2026-03-19):
 ----------------------------
+**Issue #49: Pause Timer**
+
+- Dealer can pause, resume, and reset the blind level timer
+- Pause/resume/reset buttons appear in the timer section (dealer only)
+- Paused timer shows blinking amber countdown to indicate paused state
+- Dealing cards or flipping community cards auto-resumes a paused timer
+- Reset restarts timer from full 7:00 duration and clears blindsWillIncrease
+- Timer pause state persists across server restarts (stored in database)
+- Non-dealer players and community display see paused visual state but no controls
+
+Previous Changes (2026-03-01):
+------------------------------
 **Fix for 4 GitHub Issues (Issues #44, #45, #46, #47)**
 
 - **Issue #44: Pause timer after expiration**
@@ -991,6 +1003,22 @@ Scenario 49: Anyone Can Become Dealer (Issue #32)
 8. Click "Random Dealer" - verify new random dealer selected
 9. Test: During active hand (cards dealt), try clicking player name
 10. Verify dealer cannot be changed while cards are dealt
+
+Scenario 50: Pause Timer (Issue #49)
+1. Login with 2-3 players and join game
+2. Select dealer and deal cards - verify timer starts
+3. As dealer, verify pause (⏸), and reset (↻) buttons appear in timer section
+4. As non-dealer, verify NO timer control buttons are visible
+5. Click ⏸ pause - verify timer freezes with blinking amber display
+6. Verify pause button hides and resume (▶) button appears
+7. Click ▶ resume - verify timer continues from where it paused
+8. Pause again, then deal new hand - verify timer auto-resumes
+9. Pause again, then flip community card - verify timer auto-resumes
+10. Click ↻ reset - verify timer restarts from 7:00
+11. Verify reset clears "Blinds will increase" alert if present
+12. Pause timer, then restart server
+13. Verify paused state persists after restart
+14. On /community page, verify paused visual state (blinking amber, no controls)
 
 For Issues:
 ----------

--- a/public/css/game.css
+++ b/public/css/game.css
@@ -191,6 +191,46 @@
     text-shadow: 0 0 5px rgba(243, 156, 18, 0.3);
 }
 
+/* Timer Pause Controls */
+.timer-controls {
+    display: flex;
+    justify-content: center;
+    gap: var(--spacing-md);
+    margin-top: var(--spacing-md);
+}
+
+.timer-control-btn {
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid var(--color-text-muted);
+    color: var(--color-text-primary);
+    padding: var(--spacing-sm) var(--spacing-lg);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    font-size: var(--font-lg);
+    transition: all 0.2s ease;
+}
+
+.timer-control-btn:hover {
+    background: rgba(255, 255, 255, 0.2);
+    border-color: var(--color-primary);
+}
+
+/* Paused Timer State */
+.timer-section.timer-paused {
+    border-color: #f39c12;
+    background: linear-gradient(135deg, #3d3520 0%, #2a2410 100%);
+}
+
+.timer-section.timer-paused .timer-countdown {
+    color: #f39c12;
+    animation: blink-paused 1.5s ease-in-out infinite;
+}
+
+@keyframes blink-paused {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.3; }
+}
+
 @keyframes pulse-warning {
     0%, 100% { opacity: 1; transform: scale(1); }
     50% { opacity: 0.8; transform: scale(1.02); }

--- a/public/js/dealer-controls.js
+++ b/public/js/dealer-controls.js
@@ -21,6 +21,21 @@ function setupDealerControls() {
         shuffleBtn.addEventListener('click', shuffleDeck);
     }
 
+    // Issue #49: Timer control handlers
+    const timerPauseBtn = document.getElementById('timerPauseBtn');
+    const timerResumeBtn = document.getElementById('timerResumeBtn');
+    const timerResetBtn = document.getElementById('timerResetBtn');
+
+    if (timerPauseBtn) {
+        timerPauseBtn.addEventListener('click', pauseTimer);
+    }
+    if (timerResumeBtn) {
+        timerResumeBtn.addEventListener('click', resumeTimer);
+    }
+    if (timerResetBtn) {
+        timerResetBtn.addEventListener('click', resetTimer);
+    }
+
     // Update dealer UI whenever game state changes
     wsClient.on('game-state', (message) => {
         updateDealerUI(message.data);
@@ -52,10 +67,48 @@ function updateDealerUI(state) {
 
     console.log('Is dealer:', isDealerNow, '- currentDealer.id:', currentDealer?.id, 'currentUser.id:', currentUser?.id);
 
+    // Issue #49: Timer controls visibility
+    const timerControls = document.getElementById('timerControls');
+    const timerPauseBtn = document.getElementById('timerPauseBtn');
+    const timerResumeBtn = document.getElementById('timerResumeBtn');
+    const timerResetBtn = document.getElementById('timerResetBtn');
+
     if (isDealerNow) {
         console.log('User IS dealer - showing controls');
         if (dealerControlsSection) {
             dealerControlsSection.classList.remove('hidden');
+        }
+
+        // Show timer controls when dealer and timer has started or blindsWillIncrease
+        const timerState = state.timerState;
+        const showTimerControls = timerState && (timerState.isRunning || timerState.isPaused || timerState.blindsWillIncrease);
+
+        if (timerControls) {
+            if (showTimerControls) {
+                timerControls.classList.remove('hidden');
+            } else {
+                timerControls.classList.add('hidden');
+            }
+        }
+
+        // Toggle pause/resume button visibility based on paused state
+        if (timerPauseBtn && timerResumeBtn) {
+            if (timerState && timerState.isPaused) {
+                timerPauseBtn.classList.add('hidden');
+                timerResumeBtn.classList.remove('hidden');
+            } else {
+                timerPauseBtn.classList.remove('hidden');
+                timerResumeBtn.classList.add('hidden');
+            }
+        }
+
+        // Show reset when timer has started or blindsWillIncrease
+        if (timerResetBtn) {
+            if (showTimerControls) {
+                timerResetBtn.classList.remove('hidden');
+            } else {
+                timerResetBtn.classList.add('hidden');
+            }
         }
 
         // Update button states based on game phase
@@ -64,6 +117,9 @@ function updateDealerUI(state) {
         console.log('User is NOT dealer - hiding controls');
         if (dealerControlsSection) {
             dealerControlsSection.classList.add('hidden');
+        }
+        if (timerControls) {
+            timerControls.classList.add('hidden');
         }
     }
 }
@@ -146,6 +202,22 @@ function shuffleDeck() {
 
     wsClient.send('shuffle-deck');
     showOverlay('Deck has been shuffled!', 'shuffle');
+}
+
+// Issue #49: Timer control functions
+function pauseTimer() {
+    if (!isDealerNow) return;
+    wsClient.send('pause-timer');
+}
+
+function resumeTimer() {
+    if (!isDealerNow) return;
+    wsClient.send('resume-timer');
+}
+
+function resetTimer() {
+    if (!isDealerNow) return;
+    wsClient.send('reset-timer');
 }
 
 // setupDealerControls() is called directly from game.js init()

--- a/public/js/timer.js
+++ b/public/js/timer.js
@@ -12,7 +12,11 @@ class BlindTimer {
         console.log('Timer update:', timerState);
         this.timerState = timerState;
 
-        if (timerState && timerState.isRunning) {
+        if (timerState && timerState.isPaused) {
+            // Timer is paused - show frozen remaining time
+            this.localRemainingSeconds = timerState.remainingSeconds;
+            this.stopLocalCountdown();
+        } else if (timerState && timerState.isRunning) {
             // Calculate local remaining time from server start time
             const startTime = new Date(timerState.startTime);
             const now = new Date();
@@ -79,7 +83,17 @@ class BlindTimer {
         timerCountdown.textContent = formattedTime;
 
         // Update timer section classes based on state
-        timerSection.classList.remove('timer-warning', 'timer-critical', 'timer-expired');
+        timerSection.classList.remove('timer-warning', 'timer-critical', 'timer-expired', 'timer-paused');
+
+        // Handle paused state
+        if (this.timerState && this.timerState.isPaused) {
+            timerSection.classList.add('timer-paused');
+            timerSection.classList.remove('timer-idle');
+            if (timerAlert) {
+                timerAlert.classList.add('hidden');
+            }
+            return;
+        }
 
         if (this.timerState && this.timerState.blindsWillIncrease) {
             timerSection.classList.add('timer-expired');

--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -73,6 +73,22 @@ db.exec(schema, (err) => {
         });
     });
 
+    // Add timer pause columns if they don't exist
+    const timerPauseMigrations = [
+        'ALTER TABLE game_state ADD COLUMN timer_paused INTEGER DEFAULT 0',
+        'ALTER TABLE game_state ADD COLUMN timer_remaining_when_paused INTEGER DEFAULT NULL'
+    ];
+
+    timerPauseMigrations.forEach(migration => {
+        db.run(migration, (err) => {
+            if (err && !err.message.includes('duplicate column')) {
+                if (!err.message.includes('duplicate column name')) {
+                    console.log(`Migration note: ${err.message}`);
+                }
+            }
+        });
+    });
+
     // Seed users
     console.log('Seeding users...');
 

--- a/server/db.js
+++ b/server/db.js
@@ -121,7 +121,9 @@ const gameStateOps = {
                     timer_duration_seconds: result.timer_duration_seconds || 420,
                     blinds_will_increase: Boolean(result.blinds_will_increase),
                     small_blind: result.small_blind || 1,
-                    big_blind: result.big_blind || 2
+                    big_blind: result.big_blind || 2,
+                    timer_paused: Boolean(result.timer_paused),
+                    timer_remaining_when_paused: result.timer_remaining_when_paused != null ? result.timer_remaining_when_paused : null
                 };
                 callback(null, parsed);
             } else {
@@ -144,7 +146,9 @@ const gameStateOps = {
                 timer_duration_seconds = ?,
                 blinds_will_increase = ?,
                 small_blind = ?,
-                big_blind = ?
+                big_blind = ?,
+                timer_paused = ?,
+                timer_remaining_when_paused = ?
             WHERE id = 1
         `;
 
@@ -161,7 +165,9 @@ const gameStateOps = {
                 gameState.timer_duration_seconds || 420,
                 gameState.blinds_will_increase ? 1 : 0,
                 gameState.small_blind || 1,
-                gameState.big_blind || 2
+                gameState.big_blind || 2,
+                gameState.timer_paused ? 1 : 0,
+                gameState.timer_remaining_when_paused != null ? gameState.timer_remaining_when_paused : null
             ],
             callback
         );
@@ -181,7 +187,9 @@ const gameStateOps = {
                 timer_duration_seconds = 420,
                 blinds_will_increase = 0,
                 small_blind = 1,
-                big_blind = 2
+                big_blind = 2,
+                timer_paused = 0,
+                timer_remaining_when_paused = NULL
             WHERE id = 1
         `;
         getDb().run(query, [], callback);

--- a/server/game-manager.js
+++ b/server/game-manager.js
@@ -13,6 +13,8 @@ class GameManager {
         this.timerStartTime = null;
         this.timerDurationSeconds = TIMER_DURATION_SECONDS;
         this.blindsWillIncrease = false;
+        this.timerPaused = false;
+        this.timerRemainingWhenPaused = null;
         this.smallBlind = DEFAULT_SMALL_BLIND;
         this.bigBlind = DEFAULT_BIG_BLIND;
         this.loadGameState();
@@ -36,6 +38,11 @@ class GameManager {
                 this.timerDurationSeconds = gameState.timer_duration_seconds || TIMER_DURATION_SECONDS;
                 this.blindsWillIncrease = gameState.blinds_will_increase || false;
                 console.log(`Timer state: startTime=${this.timerStartTime}, blindsWillIncrease=${this.blindsWillIncrease}`);
+
+                // Load pause state
+                this.timerPaused = gameState.timer_paused || false;
+                this.timerRemainingWhenPaused = gameState.timer_remaining_when_paused != null ? gameState.timer_remaining_when_paused : null;
+                console.log(`Pause state: paused=${this.timerPaused}, remaining=${this.timerRemainingWhenPaused}`);
 
                 // Load blind levels
                 this.smallBlind = gameState.small_blind || DEFAULT_SMALL_BLIND;
@@ -61,7 +68,9 @@ class GameManager {
             timer_duration_seconds: this.timerDurationSeconds,
             blinds_will_increase: this.blindsWillIncrease,
             small_blind: this.smallBlind,
-            big_blind: this.bigBlind
+            big_blind: this.bigBlind,
+            timer_paused: this.timerPaused,
+            timer_remaining_when_paused: this.timerRemainingWhenPaused
         };
 
         db.gameState.update(gameState, (err) => {
@@ -98,6 +107,11 @@ class GameManager {
     }
 
     dealCards() {
+        // Auto-resume paused timer before dealing
+        if (this.timerPaused) {
+            this.resumeTimer();
+        }
+
         this.game.dealCards();
 
         // Start timer on first deal if not already running and below max blinds
@@ -129,6 +143,11 @@ class GameManager {
     }
 
     flipCommunityCard() {
+        // Auto-resume paused timer before flipping
+        if (this.timerPaused) {
+            this.resumeTimer();
+        }
+
         console.log(`Flipping community card, current phase: ${this.game.phase}`);
 
         switch (this.game.phase) {
@@ -167,9 +186,22 @@ class GameManager {
     }
 
     getTimerState() {
+        if (this.timerPaused) {
+            return {
+                isRunning: false,
+                isPaused: true,
+                startTime: null,
+                durationSeconds: this.timerDurationSeconds,
+                remainingSeconds: this.timerRemainingWhenPaused || this.timerDurationSeconds,
+                expired: false,
+                blindsWillIncrease: this.blindsWillIncrease
+            };
+        }
+
         if (!this.timerStartTime) {
             return {
                 isRunning: false,
+                isPaused: false,
                 startTime: null,
                 durationSeconds: this.timerDurationSeconds,
                 remainingSeconds: this.timerDurationSeconds,
@@ -186,6 +218,7 @@ class GameManager {
 
         return {
             isRunning: true,
+            isPaused: false,
             startTime: this.timerStartTime,
             durationSeconds: this.timerDurationSeconds,
             remainingSeconds: remainingSeconds,
@@ -195,6 +228,10 @@ class GameManager {
     }
 
     checkAndUpdateTimerExpiration() {
+        if (this.timerPaused) {
+            return false;
+        }
+
         const timerState = this.getTimerState();
 
         if (timerState.expired && !this.blindsWillIncrease) {
@@ -217,6 +254,53 @@ class GameManager {
         return dealer && dealer.id === userId;
     }
 
+    pauseTimer() {
+        if (this.timerPaused || !this.timerStartTime) {
+            return;
+        }
+
+        const startTime = new Date(this.timerStartTime);
+        const now = new Date();
+        const elapsedSeconds = Math.floor((now - startTime) / 1000);
+        const remaining = Math.max(0, this.timerDurationSeconds - elapsedSeconds);
+
+        this.timerRemainingWhenPaused = remaining;
+        this.timerStartTime = null;
+        this.timerPaused = true;
+
+        console.log(`Timer paused with ${remaining} seconds remaining`);
+        this.saveGameState();
+    }
+
+    resumeTimer() {
+        if (!this.timerPaused) {
+            return;
+        }
+
+        const remaining = this.timerRemainingWhenPaused || this.timerDurationSeconds;
+
+        // Back-calculate a synthetic start time so existing elapsed-time math works
+        const now = new Date();
+        const syntheticStart = new Date(now.getTime() - (this.timerDurationSeconds - remaining) * 1000);
+        this.timerStartTime = syntheticStart.toISOString();
+
+        this.timerPaused = false;
+        this.timerRemainingWhenPaused = null;
+
+        console.log(`Timer resumed with ${remaining} seconds remaining`);
+        this.saveGameState();
+    }
+
+    resetTimer() {
+        this.timerStartTime = new Date().toISOString();
+        this.timerPaused = false;
+        this.timerRemainingWhenPaused = null;
+        this.blindsWillIncrease = false;
+
+        console.log('Timer reset to full duration');
+        this.saveGameState();
+    }
+
     resetGame() {
         console.log('Resetting game...');
         this.game = new PokerGame();
@@ -225,6 +309,8 @@ class GameManager {
         this.timerStartTime = null;
         this.timerDurationSeconds = TIMER_DURATION_SECONDS;
         this.blindsWillIncrease = false;
+        this.timerPaused = false;
+        this.timerRemainingWhenPaused = null;
 
         // Reset blind levels
         this.smallBlind = DEFAULT_SMALL_BLIND;

--- a/server/websocket.js
+++ b/server/websocket.js
@@ -224,6 +224,18 @@ function handleMessage(ws, data, setUser) {
                 handleTogglePlayerBroke(userId, data.playerId, ws);
                 break;
 
+            case 'pause-timer':
+                handlePauseTimer(userId, ws);
+                break;
+
+            case 'resume-timer':
+                handleResumeTimer(userId, ws);
+                break;
+
+            case 'reset-timer':
+                handleResetTimer(userId, ws);
+                break;
+
             case 'get-state':
                 const gameState = gameManager.getGameState(userId);
                 ws.send(JSON.stringify({
@@ -618,6 +630,40 @@ function handleTogglePlayerBroke(userId, playerId, ws) {
             message: error.message
         }));
     }
+}
+
+// Issue #49: Timer control handlers
+function handlePauseTimer(userId, ws) {
+    if (!gameManager.isDealer(userId)) {
+        ws.send(JSON.stringify({ type: 'error', message: 'Only the dealer can pause the timer' }));
+        return;
+    }
+
+    gameManager.pauseTimer();
+    console.log('Timer paused by dealer');
+    broadcastGameState();
+}
+
+function handleResumeTimer(userId, ws) {
+    if (!gameManager.isDealer(userId)) {
+        ws.send(JSON.stringify({ type: 'error', message: 'Only the dealer can resume the timer' }));
+        return;
+    }
+
+    gameManager.resumeTimer();
+    console.log('Timer resumed by dealer');
+    broadcastGameState();
+}
+
+function handleResetTimer(userId, ws) {
+    if (!gameManager.isDealer(userId)) {
+        ws.send(JSON.stringify({ type: 'error', message: 'Only the dealer can reset the timer' }));
+        return;
+    }
+
+    gameManager.resetTimer();
+    console.log('Timer reset by dealer');
+    broadcastGameState();
 }
 
 function broadcastGameState() {

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -84,6 +84,11 @@
                             <div id="timerAlert" class="timer-alert hidden">
                                 Blinds will increase next hand!
                             </div>
+                            <div id="timerControls" class="timer-controls hidden">
+                                <button id="timerPauseBtn" class="timer-control-btn" title="Pause Timer">⏸</button>
+                                <button id="timerResumeBtn" class="timer-control-btn hidden" title="Resume Timer">▶</button>
+                                <button id="timerResetBtn" class="timer-control-btn" title="Reset Timer">↻</button>
+                            </div>
                         </div>
                     </section>
 


### PR DESCRIPTION
## Summary
- Dealers can pause, resume, and reset the blind level timer during gameplay
- Paused timer displays blinking amber countdown; dealing or flipping cards auto-resumes
- Timer pause state persists in the database across server restarts
- Non-dealer players and community display see paused visual state but no controls

## Changes
- **DB**: Added `timer_paused` and `timer_remaining_when_paused` columns with migration
- **Server**: `pauseTimer()`, `resumeTimer()`, `resetTimer()` methods in GameManager
- **WebSocket**: `pause-timer`, `resume-timer`, `reset-timer` message handlers with dealer guard
- **UI**: Timer control buttons (⏸/▶/↻) in timer section, visible to dealer only
- **CSS**: Blinking amber animation for paused state

## Test plan
- [ ] `npm run db:init` runs migration without errors
- [ ] Deal cards → timer starts → pause button freezes timer with blinking display
- [ ] Resume button continues timer from paused time
- [ ] Pause → deal new hand → timer auto-resumes
- [ ] Pause → flip community card → timer auto-resumes
- [ ] Reset restarts timer from 7:00 and clears blindsWillIncrease
- [ ] Non-dealer users do NOT see timer controls
- [ ] Community display shows paused visual state (no controls)
- [ ] Restart server → paused state persists correctly

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)